### PR TITLE
Chunked Extract

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 /spec/reports/
 /tmp/
 *.gem
+.rbenv-gemsets

--- a/lib/pure/extractor.rb
+++ b/lib/pure/extractor.rb
@@ -43,7 +43,7 @@ module Pure
 
         formatted_results = format_results_for_type type, returned_collection
 
-        write_results_to_file formatted_results, output_file, type.to_s
+        write_results_to_file formatted_results, output_file
         
         update_progress_bar progress_bar, chunk_size, collection_count
 
@@ -129,7 +129,7 @@ module Pure
       
     end
     
-    def self.write_results_to_file results, file, collection_name
+    def self.write_results_to_file results, file
       
       File.open(file, "w") do |f|
         f.write(JSON.pretty_generate(results))

--- a/lib/pure/extractor.rb
+++ b/lib/pure/extractor.rb
@@ -6,7 +6,7 @@ require 'ruby-progressbar'
 module Pure
   module Extractor
     
-    def self.extract type, output_file
+    def self.extract type, chunk_size, output_directory
       
       collection = Puree::Collection.new resource: type
       
@@ -17,13 +17,23 @@ module Pure
       progress_bar = ProgressBar.create(format: "%a %e %b\u{15E7}%i %p%% %t", progress_mark: ' ', remainder_mark: "\u{FF65}", total: collection_count)
       
       offset = 0
-      limit = 20
-      
-      results = []
+      file_id = 0
+
+      if chunk_size.nil? || chunk_size.empty?
+        chunk_size = 200
+      end
+
+      chunk_size = chunk_size.to_i
       
       while offset < collection_count do
+
+        file_id += 1
+
+        filename = type.to_s + "_#{file_id.to_s.rjust(6, '0')}"
+
+        output_file = output_directory + "/#{filename}.json"
         
-        returned_collection = collection.find limit: limit, offset: offset
+        returned_collection = collection.find limit: chunk_size, offset: offset
         
         returned_collection.each do |item|
           
@@ -31,17 +41,15 @@ module Pure
         
         end
 
-        results.concat(returned_collection)
-        
-        update_progress_bar progress_bar, limit, collection_count
+        formatted_results = format_results_for_type type, returned_collection
 
-        offset += limit
+        write_results_to_file formatted_results, output_file, type.to_s
+        
+        update_progress_bar progress_bar, chunk_size, collection_count
+
+        offset += chunk_size
 
       end
-
-      formatted_results = format_results_for_type type, results
-      
-      write_results_to_file formatted_results, output_file, type.to_s
       
     end
 
@@ -122,8 +130,6 @@ module Pure
     end
     
     def self.write_results_to_file results, file, collection_name
-      
-      puts "Writing #{collection_name} to #{file}"
       
       File.open(file, "w") do |f|
         f.write(JSON.pretty_generate(results))

--- a/lib/pure/extractor/commands/pure_command.rb
+++ b/lib/pure/extractor/commands/pure_command.rb
@@ -5,7 +5,7 @@ module Pure
     module Commands
       class PureCommand < Clamp::Command
         
-        option ["-o", "--output-file"], "file", "file to output to, when extracting all this is the folder to place output files", required: true
+        option ["-o", "--output-file"], "file", "file to output to", required: true
         option ["-s", "--server"], "server", "Full url to Pure WS rest server", required: true
         option ["-u", "--username"], "username", "Username to connect to Pure WS"
         option ["-p", "--password"], "password", "Password to connect to Pure WS"

--- a/lib/pure/extractor/commands/pure_command.rb
+++ b/lib/pure/extractor/commands/pure_command.rb
@@ -5,10 +5,11 @@ module Pure
     module Commands
       class PureCommand < Clamp::Command
         
-        option ["-o", "--output-file"], "file", "file to output to", required: true
+        option ["-o", "--output-dir"], "output-dir", "Directory to store generated files in", required: true
         option ["-s", "--server"], "server", "Full url to Pure WS rest server", required: true
         option ["-u", "--username"], "username", "Username to connect to Pure WS"
         option ["-p", "--password"], "password", "Password to connect to Pure WS"
+        option ["-c", "--chunk-size"], "chunk-size", "Number of entities to extract per file, defaults to 200"
         
       end
     end

--- a/lib/pure/extractor/commands/pure_extractor.rb
+++ b/lib/pure/extractor/commands/pure_extractor.rb
@@ -8,7 +8,7 @@ module Pure
         
         include Pure::Extractor::ConfigurePuree
         
-        valid_extracts = [:organisation, :people, :projects, :publications, :datasets, :all]
+        valid_extracts = [:organisation, :people, :projects, :publications, :datasets]
         
         parameter "EXTRACT", "what to extract from pure, valid options are #{valid_extracts.map{|v| v.to_s}}" do |s|
           
@@ -27,26 +27,8 @@ module Pure
         def execute
           
           configure_puree server, username, password
-        
-          case extract
             
-          when :all
-            
-            valid_extracts.each do |extract|
-              
-              next unless extract != :all
-              
-              filename = output_file + "/" + extract.to_s + ".json"
-              
-              Pure::Extractor.extract pure_collections[extract], filename
-              
-            end
-            
-          else
-            
-            Pure::Extractor.extract pure_collections[extract], output_file
-            
-          end
+          Pure::Extractor.extract pure_collections[extract], output_file
           
         end
         

--- a/lib/pure/extractor/commands/pure_extractor.rb
+++ b/lib/pure/extractor/commands/pure_extractor.rb
@@ -28,7 +28,7 @@ module Pure
           
           configure_puree server, username, password
             
-          Pure::Extractor.extract pure_collections[extract], output_file
+          Pure::Extractor.extract pure_collections[extract], chunk_size, output_dir
           
         end
         


### PR DESCRIPTION
Change to use chunked extract from pure so a numeric incremented file is written for each extracted chunk size instead of one large file.

This should improve performance when extracting large complete collections from Pure via Puree especially when collection sizes are 50,000+.