### PR TITLE
Puree version lock

### DIFF
--- a/pure-extractor.gemspec
+++ b/pure-extractor.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "clamp"
-  spec.add_dependency "puree"
+  spec.add_dependency "puree", "~> 0.19.1"
   spec.add_dependency "ruby-progressbar"
 
   spec.add_dependency "bundler", "~> 1.12"


### PR DESCRIPTION
Lock puree to version 0.19.1 as major changes have occurred in the v 1.0.0 release